### PR TITLE
fix(blockmap): write full 8-byte XBM1 prefix header

### DIFF
--- a/src/blockmap.cpp
+++ b/src/blockmap.cpp
@@ -349,7 +349,7 @@ static void CompressBlockmap(level_t &level)
 }
 
 // compute size of final BLOCKMAP lump.
-static size_t CalcBlockmapSize(level_t &level, std::string prefix = "", size_t PrefixSize = 0,
+static size_t CalcBlockmapSize(level_t &level, std::string_view prefix = "", size_t PrefixSize = 0,
                                size_t NumSize = sizeof(uint16_t), size_t RawHeaderSize = sizeof(raw_blockmap_header_t))
 {
   size_t size = PrefixSize;
@@ -379,8 +379,8 @@ static size_t CalcBlockmapSize(level_t &level, std::string prefix = "", size_t P
 
   if (HAS_BIT(config.debug, DEBUG_BLOCKMAP))
   {
-    PrintLine(LOG_DEBUG, "[%s] Lump prefix header \'%s\', num type size of %zu, total size of %zu", __func__, prefix.c_str(),
-              NumSize, size);
+    PrintLine(LOG_DEBUG, "[%s] Lump prefix header \'%.*s\', num type size of %zu, total size of %zu", __func__,
+              static_cast<int32_t>(prefix.size()), prefix.data(), NumSize, size);
   }
 
   return size;
@@ -388,7 +388,7 @@ static size_t CalcBlockmapSize(level_t &level, std::string prefix = "", size_t P
 
 // final phase: write it out in the correct format
 template <typename NumType = uint16_t>
-static void WriteBlockmap(level_t &level, std::string prefix = "")
+static void WriteBlockmap(level_t &level, std::string_view prefix = "")
 {
   static constexpr size_t PrefixHeaderSize = 8; // "XBM1\0\0\0\0"
   size_t PrefixSize = (!prefix.empty() ? PrefixHeaderSize : 0);

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -40,6 +40,7 @@
 #include <bit>
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <vector>
 
 //
@@ -873,9 +874,11 @@ constexpr auto BSP_MAGIC_GLV3 = "gNd3";
 constexpr auto BSP_MAGIC_GLV4 = "gNd4";
 constexpr auto BSP_MAGIC_GLV5 = "gNd5";
 
-constexpr auto BMAP_MAGIC_XBM1 = "XBM1\0\0\0\0";
+using namespace std::string_view_literals;
 
-constexpr auto BMAP_MAGIC_ZBM1 = "ZBM1\0\0\0\0";
+constexpr std::string_view BMAP_MAGIC_XBM1 = "XBM1\0\0\0\0"sv;
+
+constexpr std::string_view BMAP_MAGIC_ZBM1 = "ZBM1\0\0\0\0"sv;
 
 // Upper-most bit is used for distinguishing sub-sectors, i.e tree leaves
 constexpr uint16_t NF_SUBSECTOR_VANILLA = UINT16_C(0x8000);


### PR DESCRIPTION
## Summary

Fix an uninitialized-memory write in the XBM1 blockmap lump header. The 4 trailing null bytes of the 8-byte magic prefix were being silently dropped at a C-string-to-std::string conversion, and `lump->Write(prefix.data(), 8)` then wrote whatever heap memory happened to sit after the 4-byte "XBM1" in the internal buffer.

Fixes #80.

## Why this matters

In `src/core.hpp:876`:

```cpp
constexpr auto BMAP_MAGIC_XBM1 = "XBM1\0\0\0\0";
```

`constexpr auto` deduces `const char *`. When `WriteBlockmap` took this by `std::string` (`src/blockmap.cpp:391`), the `std::string(const char *)` c-string constructor stopped at the first embedded null, producing a length-4 string. The very next line asked the lump to write exactly 8 bytes from `prefix.data()`:

```cpp
lump->Write(prefix.data(), PrefixHeaderSize);  // 8
```

The 4 extra bytes came from whatever followed the `"XBM1"` payload in the string's small-buffer/heap allocation. The XBM1 format expects those to be zero (the issue's exact wording is "partially garbage data").

## Changes

`src/core.hpp`:

- Add `<string_view>` to the includes.
- Introduce `using namespace std::string_view_literals;` so the `sv` suffix is in scope for these constants.
- Change both `BMAP_MAGIC_XBM1` and `BMAP_MAGIC_ZBM1` from `constexpr auto = "..."` to `constexpr std::string_view ... = "..."sv`. The `sv` literal preserves the exact length including the embedded nulls (length 8, not truncated at the first `\0`).

`src/blockmap.cpp`:

- `WriteBlockmap(level_t&, std::string prefix)` -> `WriteBlockmap(level_t&, std::string_view prefix)`.
- `CalcBlockmapSize(level_t&, std::string prefix, ...)` -> same with `std::string_view`.
- Fix the `PrintLine` debug format from `%s + prefix.c_str()` to `%.*s + (int, prefix.data())` since `std::string_view` is not guaranteed to be null-terminated.

The callers (`WriteBlockmap<uint32_t>(level, BMAP_MAGIC_XBM1)` at line 487) now pass the `std::string_view` directly - no conversion, no truncation.

## Testing

```
cmake .. -DCMAKE_BUILD_TYPE=Debug && make -j4
# Built target elfbsp - clean, no new warnings
```

Manual: the conversion path is the only thing that changes, and it now preserves 8 bytes instead of 4. No functional change to the XBM1 header beyond closing the gap the issue describes.

## AI disclosure

This contribution was developed with AI assistance (Claude Code).
